### PR TITLE
feat: pass actual error message for signInPasskey function

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -84,11 +84,15 @@ export const getPasskeyActionsNative = (
 			return verified;
 		} catch (e) {
 			console.error("Passkey sign-in error:", e);
+			let errorMessage = "auth cancelled";
+			if (e instanceof Error) {
+				errorMessage = e.message;
+			}
 			return {
 				data: null,
 				error: {
 					code: "AUTH_CANCELLED",
-					message: "auth cancelled",
+					message: errorMessage,
 					status: 400,
 					statusText: "BAD_REQUEST",
 				},


### PR DESCRIPTION
What do you think of passing the actual error message to caller?
So that UI can determine if error message should be shown, e.g. cancelled shouldn't need to show a message as opposed to actual sign in with passkey error.