### PR TITLE
fix: relax expo peer dependency to ^55.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@better-fetch/fetch": "^1.1.21",
     "better-auth": "^1.6.8",
     "@better-auth/passkey": "^1.6.8",
-    "expo": "55.0.17",
+    "expo": "^55.0.0",
     "react": "*",
     "react-native": "*",
     "nanostores": "*"


### PR DESCRIPTION
## Problem

PR #21 (`fix: bump better-auth peer dependency`) changed the `expo` peer dependency from `"*"` to the **exact** version `"55.0.17"`:

https://github.com/kevcube/expo-better-auth-passkey/blob/main/package.json#L53

As a result, installing this package in any Expo SDK 55 project that isn't pinned to that exact patch (for example `"expo": "~55.0.23"`, which is what `expo@55` currently resolves to) fails with `ERESOLVE` and requires `--legacy-peer-deps` to install.

## Fix

Widen the peer dep to `^55.0.0` so any Expo SDK 55 release satisfies it, while still preventing accidental installs against SDK 54 or a future SDK 56. This matches the convention used by other Expo modules.

```diff
-    "expo": "55.0.17",
+    "expo": "^55.0.0",
```

## Test plan
- [x] `package.json` diff is a single-line peer dep change; no lockfile or source code touched.
- [ ] `npm install expo-better-auth-passkey` succeeds in an Expo SDK 55.0.23 project without `--legacy-peer-deps`.